### PR TITLE
Add refresh token endpoint test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "dev": "nodemon src/index.js"
   },
   "keywords": [
@@ -27,6 +27,8 @@
     "resend": "^4.1.1"
   },
   "devDependencies": {
-    "nodemon": "^3.1.9"
+    "nodemon": "^3.1.9",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/tests/user.refresh.test.js
+++ b/tests/user.refresh.test.js
@@ -1,0 +1,49 @@
+import request from 'supertest';
+import { app } from '../src/app.js';
+import { User } from '../src/models/user.model.js';
+import jwt from 'jsonwebtoken';
+
+jest.mock('../src/middlewares/auth.middleware.js', () => ({
+  verifyJWT: (_req, _res, next) => next(),
+}));
+
+jest.mock('../src/models/user.model.js');
+jest.mock('jsonwebtoken');
+
+describe('POST /api/v1/users/refresh-token', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.REFRESH_TOKEN_SECRET = 'secret';
+  });
+
+  it('returns new tokens for a valid refresh token', async () => {
+    const validToken = 'validRefreshToken';
+    const newAccessToken = 'newAccessToken';
+    const newRefreshToken = 'newRefreshToken';
+
+    const mockUser = {
+      _id: 'user123',
+      refreshToken: validToken,
+      generateAccessToken: jest.fn().mockReturnValue(newAccessToken),
+      generateRefreshToken: jest.fn().mockReturnValue(newRefreshToken),
+      save: jest.fn().mockResolvedValue(),
+    };
+
+    User.findById.mockResolvedValue(mockUser);
+    jwt.verify.mockReturnValue({ id: 'user123' });
+
+    const res = await request(app)
+      .post('/api/v1/users/refresh-token')
+      .set('Cookie', `refreshToken=${validToken}`)
+      .expect(200);
+
+    expect(res.body.data).toEqual({
+      accessToken: newAccessToken,
+      refreshToken: newRefreshToken,
+    });
+    const cookies = res.headers['set-cookie'].join(';');
+    expect(cookies).toContain(`refreshToken=${newRefreshToken}`);
+    expect(cookies).toContain(`accessToken=${newAccessToken}`);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Jest and Supertest as dev dependencies
- create Jest config
- implement integration test for refreshing tokens
- update test script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2c1c2028832a8f21271f06bc7cf8